### PR TITLE
New macros `Prometheus.@time` and `Prometheus.@inprogress`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+ - New macro `Prometheus.@time collector <expr>` for timing `<expr>` and pass the elapsed
+   time to the collector. `<expr>` can be a single expression, a block, or a function
+   *definition*. In the latter case, all calls to the function will be instrumented (no
+   matter the call site). See documentation for more details. ([#6][github-6])
+ - New macro `Prometheus.@inprogress collector <expr>` to track number of in-progress
+   concurrent evalutations of `<expr>`. Just like `Prometheus.@time`, valid `<expr>`s are
+   single expressions, blocks, and function definitions. See documentation for more details.
+   ([#6][github-6])
 
 ## [1.0.1] - 2023-11-06
 ### Fixed
@@ -27,6 +36,8 @@ First stable release of Prometheus.jl:
 
 See [README.md](README.md) for details and documentation.
 
+
+[github-6]: https://github.com/fredrikekre/Prometheus.jl/pull/6
 
 [Unreleased]: https://github.com/fredrikekre/Prometheus.jl/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/fredrikekre/Prometheus.jl/compare/v1.0.0...v1.0.1

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -107,6 +107,8 @@ Prometheus.inc(::Prometheus.Gauge, ::Any)
 Prometheus.dec(::Prometheus.Gauge, ::Any)
 Prometheus.set(::Prometheus.Gauge, ::Any)
 Prometheus.set_to_current_time(::Prometheus.Gauge)
+Prometheus.@time
+Prometheus.@inprogress
 ```
 
 ### Summary
@@ -123,6 +125,9 @@ documentation](https://prometheus.io/docs/concepts/metric_types/#summary):
 ```@docs
 Prometheus.Summary(::String, ::String; kwargs...)
 Prometheus.observe(::Prometheus.Summary, ::Any)
+```
+```@docs; canonical=false
+Prometheus.@time
 ```
 
 ### GCCollector


### PR DESCRIPTION
New macros `Prometheus.@time` and `Prometheus.@inprogress`:
- New macro `Prometheus.@time collector <expr>` for timing `<expr>` and pass the elapsed time to the collector.
- New macro `Prometheus.@inprogress collector <expr>` to track number of in-progress concurrent evalutations of `<expr>`.

In both cases, `<expr>` can be a single expression, a block, or a function *definition*. In the latter case, all calls to the function will be instrumented (no matter the call site). See documentation for more details.