### PR TITLE
Family{C}: Generalize labeling specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    concurrent evalutations of `<expr>`. Just like `Prometheus.@time`, valid `<expr>`s are
    single expressions, blocks, and function definitions. See documentation for more details.
    ([#6][github-6])
+ - New ways to specify label names and label values in `Prometheus.Family{C}`. Label names
+   can now be passed to the constructor as i) a tuple of strings or symbols, ii) a named
+   tuple type (names used for label names), or iii) a custom struct type (field names used
+   for label names). Similarly, label values (passed to e.g. `Prometheus.labels`) can be
+   passed as i) tuple of strings, ii) named tuple, iii) struct instance. See documentation
+   for examples and more details. ([#7][github-7])
 
 ## [1.0.1] - 2023-11-06
 ### Fixed
@@ -38,6 +44,7 @@ See [README.md](README.md) for details and documentation.
 
 
 [github-6]: https://github.com/fredrikekre/Prometheus.jl/pull/6
+[github-7]: https://github.com/fredrikekre/Prometheus.jl/pull/7
 
 [Unreleased]: https://github.com/fredrikekre/Prometheus.jl/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/fredrikekre/Prometheus.jl/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
This patch changes how label names and label values can be passed to the constructor `Prometheus.Family{C}` and `Prometheus.labels`. In particular, the label names are now stored as symbols internally. This enables using `getfield` when creating the corresponding label values. Concretely this enables using e.g. named tuples, and custom structs, as label names/values.

For example, the following now works
```julia
struct RequestLabels
    target::String
    status_code::Int
end
request_counter = Prometheus.Family{Prometheus.Counter}(
    "http_requests", "Total number of HTTP requests", RequestLabels
)
counter = Prometheus.labels(request_counter, RequestLabels("/api", 200))
```
In this example, the field names of the type, `RequestLabels`, are used as label names in the `Family{C}` constructor. When extracting the counter for a specific set of labels an instance of the struct is used. All non-string values are stringified using string (`status_code::Int` in the example above, for example).