### PR TITLE
Mark public API with the public keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.0] - 2024-07-12
+### Changed
+ - The public API of Prometheus.jl is now marked `public` in Julia versions that support it.
+   The public names are: `CollectorRegistry`, `register`, `unregister`, `Counter`, `Gauge`,
+   `Histogram`, `Summary`, `GCCollector`, `ProcessCollector`, `inc`, `dec`, `set`,
+   `set_to_current_time`, `observe`, `@inprogress`, `@time`, `Family`, `labels`, `remove`,
+   `clear`, and `expose`. ([#19])
+
 ## [v1.3.0] - 2023-11-29
 ### Added
  - `Base.getindex` is overloaded for the `Prometheus.Family` collector to have the same

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Prometheus"
 uuid = "f25c1797-fe98-4e0c-b252-1b4fe3b6bde6"
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.2"
+julia_version = "1.10.4"
 manifest_format = "2.0"
 project_hash = "53cbdb0f6aa70ecb8ff1b1f6baa22bced23c24e5"
 
@@ -244,7 +244,7 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 deps = ["CodecZlib", "HTTP", "SimpleBufferStream"]
 path = ".."
 uuid = "f25c1797-fe98-4e0c-b252-1b4fe3b6bde6"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]

--- a/src/Prometheus.jl
+++ b/src/Prometheus.jl
@@ -6,6 +6,17 @@ using CodecZlib: GzipCompressorStream
 using HTTP: HTTP
 using SimpleBufferStream: BufferStream
 
+if VERSION >= v"1.11.0-DEV.469"
+    eval(Meta.parse("""
+        public CollectorRegistry, register, unregister,
+            Counter, Gauge, Histogram, Summary, GCCollector, ProcessCollector,
+            inc, dec, set, set_to_current_time, observe, @inprogress, @time,
+            Family, labels, remove, clear,
+            expose
+    """
+    ))
+end
+
 abstract type Collector end
 
 #########


### PR DESCRIPTION
This patch marks the public API of Prometheus.jl with the `public` keyword in Julia versions that support it.

The public symbols are: `CollectorRegistry`, `register`, `unregister`, `Counter`, `Gauge`, `Histogram`, `Summary`, `GCCollector`, `ProcessCollector`, `inc`, `dec`, `set`, `set_to_current_time`, `observe`, `@inprogress`, `@time`, `Family`, `labels`, `remove`, `clear`, and `expose`.