### PR TITLE
Add "_bucket" suffix to histogram Samples

### DIFF
--- a/src/Prometheus.jl
+++ b/src/Prometheus.jl
@@ -422,7 +422,7 @@ function collect!(metrics::Vector, histogram::Histogram)
     samples[2] = Sample("_sum", nothing, nothing, @atomic(histogram._sum))
     for i in 1:length(histogram.buckets)
         sample = Sample(
-            nothing, label_names, make_label_values(label_names, (histogram.buckets[i],)),
+            "_bucket", label_names, make_label_values(label_names, (histogram.buckets[i],)),
             histogram.bucket_counters[i][],
         )
         samples[2 + i] = sample


### PR DESCRIPTION
Issue addressed by this PR:
According to the upstream documentation here - bucket counts should take the form <basename>_bucket{le="..."}.  However, the current code does not add the "_bucket" suffix.

Background:
I discovered this trying to have DataDog import the bucket values.  OpenMetrics Histograms were not being processed correctly by DataDog after verifying that I had setup the agent correctly.  DataDog was capturing the _count and _sum values but not the buckets.  Once I made the change in this PR, the agent started loading the histograms properly. 
