### PR TITLE
Reject scrapes whose `Accept` header excludes our text format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+ - `expose(::HTTP.Stream)` responses now include `Vary: Accept, Accept-Encoding`, signalling
+   to shared caches (proxies, CDNs) that the response depends on both request headers.
+   ([#35])
+### Changed
+ - `expose(::HTTP.Stream)` now honors the request's `Accept` header. If the client sent an
+   `Accept` header that doesn't include `text/plain; version=0.0.4` (or a compatible
+   superset such as `text/plain`, `text/*`, or `*/*`) with non-zero q-value, the response
+   is now `406 Not Acceptable`. Requests without an `Accept` header, or with `*/*`, are
+   unaffected — so curl, browsers, and standard Prometheus scrapers all continue to work.
+   ([#35])
+
 ## [v1.5.1] - 2026-07-03
 ### Fixed
  - `Summary` collectors now reserve the base metric name in addition to `_count`/`_sum`, so
@@ -114,3 +127,4 @@ See [README.md](README.md) for details and documentation.
 [#30]: https://github.com/fredrikekre/Prometheus.jl/issues/30
 [#31]: https://github.com/fredrikekre/Prometheus.jl/issues/31
 [#34]: https://github.com/fredrikekre/Prometheus.jl/issues/34
+[#35]: https://github.com/fredrikekre/Prometheus.jl/issues/35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
- - `expose(::HTTP.Stream)` responses now include `Vary: Accept, Accept-Encoding`, signalling
-   to shared caches (proxies, CDNs) that the response depends on both request headers.
-   ([#35])
 ### Changed
  - `expose(::HTTP.Stream)` now honors the request's `Accept` header. If the client sent an
    `Accept` header that doesn't include `text/plain; version=0.0.4` (or a compatible
    superset such as `text/plain`, `text/*`, or `*/*`) with non-zero q-value, the response
    is now `406 Not Acceptable`. Requests without an `Accept` header, or with `*/*`, are
    unaffected — so curl, browsers, and standard Prometheus scrapers all continue to work.
+   ([#35])
+ - `expose(::HTTP.Stream)` responses now include `Vary: Accept, Accept-Encoding`, signalling
+   to shared caches (proxies, CDNs) that the response depends on both request headers.
    ([#35])
 
 ## [v1.5.1] - 2026-07-03

--- a/src/Prometheus.jl
+++ b/src/Prometheus.jl
@@ -1107,6 +1107,72 @@ end
 
 const CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
 
+# RFC 9110 §12.5.1: whether a client that sent this Accept header would accept
+# our fixed output, `text/plain; version=0.0.4`. Returns true iff:
+#   - Accept is absent/empty (spec: no Accept => any media type is acceptable), or
+#   - the most-specific matching media range has q > 0.
+#
+# We currently emit exactly one format, so this is a boolean gate rather than a
+# preference-ordered picker. When a second format (OpenMetrics, protobuf) lands,
+# this needs to grow into "pick the highest-q supported entry" and echo the
+# chosen Content-Type. Any `version` parameter on the Accept entry must equal
+# `0.0.4` to match; other non-q parameters (e.g. `charset`) are ignored —
+# Prometheus scrapers don't send them as filters in practice.
+accepts_prom_text_004(http::HTTP.Stream) =
+    accepts_prom_text_004(HTTP.header(http.message, "Accept"))
+
+function accepts_prom_text_004(accept::AbstractString)
+    isempty(strip(accept)) && return true
+    best_specificity = -1
+    best_q = 0.0
+    for entry in eachsplit(accept, ',')
+        parts = eachsplit(entry, ';')
+        media = lowercase(strip(first(parts)))
+        slash = findfirst('/', media)
+        slash === nothing && continue
+        type = SubString(media, 1, prevind(media, slash))
+        subtype = SubString(media, nextind(media, slash))
+        q = 1.0
+        version_param = nothing
+        for param in Iterators.drop(parts, 1)
+            kv = strip(param)
+            eq = findfirst('=', kv)
+            eq === nothing && continue
+            key = lowercase(strip(SubString(kv, 1, prevind(kv, eq))))
+            val = strip(SubString(kv, nextind(kv, eq)))
+            if length(val) >= 2 && first(val) == '"' && last(val) == '"'
+                val = SubString(val, 2, prevind(val, lastindex(val)))
+            end
+            if key == "q"
+                q = something(tryparse(Float64, val), 0.0)
+            elseif key == "version"
+                version_param = val
+            end
+        end
+        specificity = if type == "*" && subtype == "*"
+            0
+        elseif type == "text" && subtype == "*"
+            1
+        elseif type == "text" && subtype == "plain"
+            if version_param === nothing
+                2
+            elseif version_param == "0.0.4"
+                3
+            else
+                -1
+            end
+        else
+            -1
+        end
+        if specificity > best_specificity ||
+                (specificity == best_specificity && q > best_q)
+            best_specificity = specificity
+            best_q = q
+        end
+    end
+    return best_specificity >= 0 && best_q > 0
+end
+
 gzip_accepted(http::HTTP.Stream) =
     gzip_accepted(HTTP.header(http.message, "Accept-Encoding"))
 
@@ -1143,7 +1209,20 @@ The caller is responsible for checking e.g. the HTTP method and URI target. For
 HEAD requests this method do not write a body, however.
 """
 function expose(http::HTTP.Stream, reg::CollectorRegistry = DEFAULT_REGISTRY; compress::Bool = true)
-    # TODO: Handle Accept request header for different formats?
+    # Content negotiation: we only speak text/plain;version=0.0.4. If the client
+    # sent an Accept header that excludes it, return 406. See REVIEW.md E1.
+    # Signal to shared caches that the response depends on both Accept (200 vs
+    # 406) and Accept-Encoding (gzip vs identity). RFC 9110 §12.5.5.
+    HTTP.setheader(http, "Vary" => "Accept, Accept-Encoding")
+    if !accepts_prom_text_004(http)
+        HTTP.setstatus(http, 406)
+        HTTP.setheader(http, "Content-Type" => "text/plain; charset=utf-8")
+        HTTP.startwrite(http)
+        if http.message.method != "HEAD"
+            write(http, "406 Not Acceptable: server only produces $(CONTENT_TYPE_LATEST)\n")
+        end
+        return
+    end
     # Compress by default if client supports it and user haven't disabled it
     if compress
         compress = gzip_accepted(http)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -815,6 +815,8 @@ end
     r_default = HTTP.request("GET", "http://localhost:8123/metrics/default")
     r_ref = HTTP.request("GET", "http://localhost:8123/metrics/reg")
     @test String(r_default.body) == String(r_ref.body) == reference_output
+    # Vary header is set so shared caches key on Accept and Accept-Encoding.
+    @test HTTP.header(r_default, "Vary") == "Accept, Accept-Encoding"
     # HEAD
     @test isempty(HTTP.request("HEAD", "http://localhost:8123/metrics/default").body)
     # POST (no filtering in the server above)
@@ -869,6 +871,57 @@ end
     @test Prometheus.gzip_accepted("*;q=0") == false
     # An explicit gzip entry takes precedence over the wildcard.
     @test Prometheus.gzip_accepted("gzip;q=0, *;q=1") == false
+
+    # Server-side Accept negotiation (RFC 9110 §12.5.1). We only speak
+    # `text/plain; version=0.0.4`; the check is a boolean gate.
+    # Absent/empty Accept => any media type is acceptable.
+    @test Prometheus.accepts_prom_text_004("") == true
+    # Direct hits.
+    @test Prometheus.accepts_prom_text_004("text/plain") == true
+    @test Prometheus.accepts_prom_text_004("text/plain; version=0.0.4") == true
+    @test Prometheus.accepts_prom_text_004("text/plain;version=0.0.4;q=0.25") == true
+    # Wildcards match.
+    @test Prometheus.accepts_prom_text_004("*/*") == true
+    @test Prometheus.accepts_prom_text_004("text/*") == true
+    # A non-matching version param is a mismatch.
+    @test Prometheus.accepts_prom_text_004("text/plain; version=1.0.0") == false
+    # Other media types don't match.
+    @test Prometheus.accepts_prom_text_004(
+        "application/openmetrics-text; version=1.0.0",
+    ) == false
+    # A modern Prometheus scrape sends us at q=0.25 alongside OpenMetrics; still fine.
+    @test Prometheus.accepts_prom_text_004(
+        "application/openmetrics-text;version=1.0.0;q=0.75," *
+            "application/openmetrics-text;version=0.0.1;q=0.5," *
+            "text/plain;version=0.0.4;q=0.25,*/*;q=0.1",
+    ) == true
+    # q=0 is explicit refusal, even alongside a matching wildcard —
+    # RFC precedence: the more specific media range wins.
+    @test Prometheus.accepts_prom_text_004("text/plain;q=0") == false
+    @test Prometheus.accepts_prom_text_004("text/plain;version=0.0.4;q=0, */*") == false
+    @test Prometheus.accepts_prom_text_004("*/*;q=0") == false
+
+    # End-to-end: a scraper that only accepts OpenMetrics gets 406.
+    r_406 = HTTP.request(
+        "GET", "http://localhost:8123/metrics/default",
+        ["Accept" => "application/openmetrics-text;version=1.0.0"];
+        status_exception = false,
+    )
+    @test r_406.status == 406
+    @test occursin("406 Not Acceptable", String(r_406.body))
+    # Vary header is also set on the 406 response — it, too, is a function of Accept.
+    @test HTTP.header(r_406, "Vary") == "Accept, Accept-Encoding"
+    # A scraper that includes us with any non-zero q still succeeds.
+    r_ok = HTTP.request(
+        "GET", "http://localhost:8123/metrics/default",
+        [
+            "Accept" => "application/openmetrics-text;version=1.0.0;q=0.75," *
+                "text/plain;version=0.0.4;q=0.25,*/*;q=0.1",
+        ],
+    )
+    @test r_ok.status == 200
+    @test String(r_ok.body) == reference_output
+
     # Clean up
     close(server)
     wait(server)


### PR DESCRIPTION
`expose(::HTTP.Stream)` used to hardcode `Content-Type: text/plain;
version=0.0.4` regardless of what the client sent. A modern scraper that
only accepts OpenMetrics or protobuf would get a text/plain body with a
200 and no signal that its preference was ignored.

Parse `Accept` into media ranges (type/subtype + params + q-value), pick
the most-specific matching entry per RFC 9110 §12.5.1 precedence, and
return 406 Not Acceptable when that entry has q=0 (or nothing matches).
Absent/empty Accept still passes — the spec says no header means any
media type is acceptable, so curl and browser defaults keep working.

Single-format gate for now; when a second format (OpenMetrics, protobuf)
lands this needs to grow into a preference-ordered picker.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
